### PR TITLE
do not reference frege release 3.22.324 anymore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
 
     dependencies {
         compile "org.codehaus.groovy:groovy:$groovyVersion"
-        compile "com.theoryinpractise.frege:frege:3.22.324-g630677b"
-        compile "frege:frege-repl-core:1.1.1-SNAPSHOT"
+        compile "com.theoryinpractise.frege:frege:3.22.367-g630677b"
+        compile "org.frege-lang:frege-repl-core:1.1.1-SNAPSHOT"
     }
 }


### PR DESCRIPTION
As this had a critical bug, we must take care that people DO NOT download it, see the newsgroup discussion.

In addition, I corrected the id of the repl
