### PR TITLE
Fix frege-gradle-plugin resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
-buildscript {        // make the frege plugin available in our build
+buildscript {
     repositories {
-		mavenLocal() // if you have the plugin installed locally, this is enough
+        mavenLocal()
+        mavenCentral()
         maven {
-            url = "https://oss.sonatype.org/content/groups/public"
+            url = 'https://jitpack.io'
         }
     }
     dependencies {
-        classpath 'org.frege-lang:frege-gradle-plugin:0.3-SNAPSHOT', {
+        classpath 'com.github.frege:frege-gradle-plugin:release-0.3', {
             exclude module: "frege-native-gen"
         }
     }


### PR DESCRIPTION
Could not get a fresh clone to build locally. Seems like the frege-gradle-plugin must now be resolved via JitPack. From their [README](https://github.com/Frege/frege-gradle-plugin/blob/master/README.adoc):

> With the 0.3 release we experimented with github releases and http://jitpack.io

Upgraded from `0.3-SNAPSHOT` to `release-0.3` while I was at it.
