### PR TITLE
Fix README docs and support Fixed width fonts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -67,13 +67,13 @@ For developers only
 Normal users please use the download link at the top of this page.
 
 [NOTE]
-Since version 0.6, FregeFX is an external dependency that you might need to `gradlew install`
+Since version 0.6, FregeFX is an external dependency that you might need to `gradlew install` (`./gradlew install` on linux and macos)
 locally if a SNAPSHOT version is referenced.
 
 
 With Java 8 (update 40 or higher) start via
 
-    gradlew clean :client:run
+    gradlew clean run
 
 
 NOTE: There is no need to install gradle or anything else beside a Java 8 JDK.

--- a/src/main/resources/frepl.css
+++ b/src/main/resources/frepl.css
@@ -17,7 +17,7 @@
     -fx-background-color: -hi-light-glow, -hi-light, -hi-light-glow;
     -fx-background-radius: 5,4,3;
     -fx-background-insets: 0, 1, 3;
-    /*-fx-font-family: monospace;*/
+    -fx-font-family: Menlo, Consolas, monospace;
     /*-fx-font-weight: bold;*/
 }
 


### PR DESCRIPTION
- I'm not sure if the fixed width font was intentionally commented out, or just an accident. I think an editor for code should have fixed width fonts.
- `gradlew` on windows is `./gradlew` on linux and MacOS systems.
- there isn't a `client` gradle subproject
- Besides these changes, I see a problem on my machine and I'm not sure what the clean way of fixing it is. 

```
:compileFrege
E /Users/rahul/src/frepl-gui/src/main/frege/org/frege/Application.fr:214: can't find a type for  ("href=\"\\.\\/".matcher content).replaceAll
     because  "href=\"\\.\\/".matcher content :: t14815  does not have a definite type.
E /Users/rahul/src/frepl-gui/src/main/frege/org/frege/Application.fr:214: can't find a type for  "href=\"\\.\\/".matcher `matcher`
    is neither an overloaded function nor a member of  Regex
org.frege.Application: build failed because of compilation errors.
```

I got past it by avoiding the regex replace of the `hrefs`.

I've just started learning haskell/frege from the course you tweeted out about, so I might soon get to the point where I might be able to fix that problem I'm facing. :)

Thanks for this project and pointing me to that course.
